### PR TITLE
Change callback context to scrollTargetElement and pass original event object

### DIFF
--- a/jquery.malihu.PageScroll2id.js
+++ b/jquery.malihu.PageScroll2id.js
@@ -25,13 +25,14 @@
 				e.preventDefault();
 				var $this=$(this);
 				var scrollTarget=$this.attr("href").split("#");
-				var scrollToPos=$("#"+scrollTarget[1]).offset().top;
+				var scrollTargetElement = $("#"+scrollTarget[1]);
+				var scrollToPos=scrollTargetElement.offset().top;
 				var docHeight=$(document).height();
 				if(options.layout==="horizontal"){ //x-axis
-					scrollToPos=$("#"+scrollTarget[1]).offset().left; 
+					scrollToPos=scrollTargetElement.offset().left; 
 					var docWidth=$(document).width(); 
 				}else if(options.layout==="auto"){ //xy-axis
-					var scrollToPosX=$("#"+scrollTarget[1]).offset().left; 
+					var scrollToPosX=scrollTargetElement.offset().left; 
 					var docWidth=$(document).width(); 
 					var scrollToX=scrollToPosX;
 				}
@@ -72,7 +73,7 @@
 					scrollTo:scrollTo,
 					speed:speed,
 					easing:easing,
-					callback:options.callback,
+					callback:$.proxy(options.callback, scrollTargetElement, e),
 					layout:options.layout,
 					scrollToX:scrollToX //xy-axis
 				});


### PR DESCRIPTION
Would like the callback function to receive the original event object (e) in order to reference the clicked element. Also would like the context to be the target element (this) in order to do additional things at the target, like focus elements.

Example:

```
        $("a[rel='m_PageScroll2id']").mPageScroll2id({
            "scrollSpeed":"2000",
            "autoScrollSpeed":"true",
            "scrollEasing":"easeInOutExpo",
            "scrollingEasing":"easeInOutCirc",
            "pageEndSmoothScroll":"true",
            "layout":"vertical",
            "callback": function(e){
                var clickedElement = $(e.target),
                    targetElement = $(this);
                clickedElement.addClass("bump");
                targetElement.highlight();
            }
        });
```
